### PR TITLE
Clarify .well-known response describes the sites compliance for the session

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,8 +307,10 @@
       <h2>GPC Support Resource</h2>
       <p>
         A site MAY produce a resource at a .well-known URL in order for a site to represent the fact
-        that it abides by GPC. The purpose of a GPC Support Resource is for a site to convey its
-        support for the Global Privacy Control. By default, an origin's support is <em>unknown</em>.
+        that the site is respecting the GPC signal for the user requesting the
+        resource. The purpose of a GPC Support Resource is for a site to convey
+        the site's support for the Global Privacy Control for the current
+        session. By default, an origin's support is <em>unknown</em>.
       </p>
       <p>
         A GPC Support Resource has the well-known identifier <code>/.well-known/gpc.json</code>
@@ -317,7 +319,8 @@
       <p>
         An origin server that receives a valid GET request targeting its GPC support resource
         responds either with a successful response containing a machine-readable representation of
-        the site-wide tracking status, as defined below, or a sequence of redirects that leads to
+        whether the site is respecting the Global Privacy Control
+        for the current session, or a sequence of redirects that leads to
         such a representation (which MAY be provided by a server at another origin).
       </p>
       <section>
@@ -335,7 +338,8 @@
           <ul>
             <li>
               A <code>gpc</code> member. The value of the <code>gpc</code> member MUST be either
-              <code>true</code>, to indicate that the server intends to abide by GPC requests, or
+              <code>true</code>, to indicate that the server intends to abide by GPC requests
+              for the current session, or
               <code>false</code>, to indicate that it does not. For any other value the origin's
               support is unknown.
             </li>


### PR DESCRIPTION
This PR tries to clarify that the .well-known response is describing the site's respect for the GPC signal w/r/t the requesting user, and the requesting user's browsing session.

The .well-known response is not intended to describe what the site does for all users, for all sessions (though of course the site could provide the same response to all users, indicating that the site does (or does not) respect GPC equally for all users/sessions.