### PR TITLE
Clarify meaning of true in .well-known

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,11 +307,13 @@
       <h2>GPC Support Resource</h2>
       <p>
         A site MAY produce a resource at a .well-known URL in order for a site to represent the fact
-        that it abides by GPC. The purpose of a GPC Support Resource is for a site to convey its
-        support for the Global Privacy Control. By default, an origin's support is <em>unknown</em>.
+        that it abides by GPC requests, at least where required to do so. The purpose of a GPC support
+        resource is for a site to convey its awareness of and support for the Global Privacy Control.
+        The support resource is not intended to convey whether the site abides by GPC requests from
+        the user agent accessing the resource. By default, an origin's support is <em>unknown</em>.
       </p>
       <p>
-        A GPC Support Resource has the well-known identifier <code>/.well-known/gpc.json</code>
+        A GPC support resource has the well-known identifier <code>/.well-known/gpc.json</code>
         relative to the origin server's URL [[RFC8615]].
       </p>
       <p>
@@ -335,9 +337,9 @@
           <ul>
             <li>
               A <code>gpc</code> member. The value of the <code>gpc</code> member MUST be either
-              <code>true</code>, to indicate that the server intends to abide by GPC requests, or
-              <code>false</code>, to indicate that it does not. For any other value the origin's
-              support is unknown.
+              <code>true</code>, to indicate that the server intends to abide by GPC requests at least
+              to the extent it is legally obligated to do so, or <code>false</code>, to indicate that
+              it does not. For any other value the origin's support is unknown.
             </li>
             <li>
               A <code>lastUpdate</code> member. The value of the <code>lastUpdate</code>


### PR DESCRIPTION
Based on the discussions around Issue #33 and PR #48, I have tried to restate the scope of the `.well-known` to clarify that it is a general statement of support for GPC and not session-specific. I also narrowed the meaning of `true` to say that clarify that `true` only means that a site complies with GPC in _some_ contexts, not that it necessarily respects GPC in every instance.

I had previously suggested that `true` could be interpreted to mean any of the following (I chose to define as 3(b) below for this PR but am open to being persuaded to pick another option):

(1) "I do something, somewhere in response to GPC"
(2) "I do something, everywhere in response to GPC" (but I think this would be a significant change from how many companies are interpreting this today)
(3) "I do something in response to GPC in the places where I am legally required to"
(3b) "I do something in response to GPC at least in the places where I am legally required to"
(4) "I do something in response to GPC in these jurisdictions" (and we provide guidance on how to list them out), or
(5) something else