### PR TITLE
Add link to the explainer for legal effects details

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,7 +393,8 @@
         Receiving a GPC signal may have legal effects, depending on
         factors such as the location of the individual sending the signal, the scope of the
         applicable law, as well as any separate agreement between the recipient of the signal and
-        the individual.
+        the individual. For additional details on legal effects, 
+        <a href="https://privacycg.github.io/gpc-spec/explainer" target="_blank">consult the explainer</a>. 
       </p>
       <p>
         For example, the use of the GPC signal by an individual will be intended to communicate the


### PR DESCRIPTION
In order to address concerns about updated to the legal effects and remove concerns about delays stemming from WG workflows that might be involved with future modification we aim to address updates to legal effects in the explainer and link to it within the specification. This hopefully will address #53 